### PR TITLE
Drop unused expert rank weight

### DIFF
--- a/data/weights.json
+++ b/data/weights.json
@@ -5,6 +5,5 @@
   "usage": 0.08,
   "injury": 0.07,
   "bye": 0.04,
-  "expert_rank": 0.04,
   "age_penalty": 0.02
 }


### PR DESCRIPTION
## Summary
- remove `expert_rank` from data weights

## Testing
- `python -m py_compile ranking/rank_engine.py`
- `python -m py_compile export_json.py`


------
https://chatgpt.com/codex/tasks/task_e_687e8a946f948323852988dd8ad6ac94