### PR TITLE
Clean unused KTC code

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ ros-rankings/
 ├── export_json.py
 ├── requirements.txt
 └── README.md
+
+The ranking engine consumes projections and usage metrics from the scrapers
+under `scrapers/`. Previous revisions referenced KeepTradeCut (KTC) values, but
+that data is no longer loaded or used in the scoring formula.

--- a/ranking/rank_engine.py
+++ b/ranking/rank_engine.py
@@ -6,11 +6,6 @@ def load_sleeper():
     path = Path("data/sleeper_players.json")
     return json.loads(path.read_text()) if path.exists() else {}
 
-def load_ktc():
-    path = Path("data/ktc_values.csv")
-    if not path.exists(): return {}
-    with path.open() as f:
-        return {row["player_name"]: float(row["value"]) for row in csv.DictReader(f)}
 
 def load_usage():
     path = Path("data/nflverse_usage.csv")
@@ -51,7 +46,6 @@ def load_prev():
 # ---------- core rank logic ----------
 def calc_rank():
     players = load_sleeper()
-    ktc = load_ktc()
     usage = load_usage()
     proj = load_ffa_proj()
     t_sched = load_team_sched()


### PR DESCRIPTION
## Summary
- drop the unused KeepTradeCut loader
- clarify in README that KTC data is no longer loaded

## Testing
- `python -m py_compile export_json.py ranking/rank_engine.py scrapers/ffa_projections.py scrapers/schedule_weights.py scrapers/usage_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_687e8a9fee0483238a8661bda95abd82