### PR TITLE
Update README scraper names

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@ ros-rankings/
 │   └── workflows/
 │       └── ros.yml            # GitHub-Actions workflow
 ├── scrapers/
-│   ├── sleeper_poll.py
-│   ├── pushshift_stream.py
-│   ├── nflverse_sync.py
-│   └── oddsapi_poll.py
+│   ├── ffa_projections.py
+│   ├── schedule_weights.py
+│   └── usage_sync.py
 ├── ranking/
+│   ├── changelog.py
 │   └── rank_engine.py         # sample below
+├── data/
+├── public/
 ├── export_json.py
 ├── requirements.txt
 └── README.md


### PR DESCRIPTION
## Summary
- fix outdated filenames in README tree diagram
- update directory listing to match repo layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e95ceb69c83238d6ee9ba954fed03