### PR TITLE
Fix ranking iteration order

### DIFF
--- a/ranking/rank_engine.py
+++ b/ranking/rank_engine.py
@@ -85,7 +85,7 @@ def calc_rank():
         ranked.append((p["position"], ros_pts, pid, p["full_name"], p["injury_status"]))
 
     final = {}
-    for pos in {"QB", "RB", "WR", "TE", "K", "DST"}:
+    for pos in ["QB", "RB", "WR", "TE", "K", "DST"]:
         seq = [r for r in ranked if r[0] == pos]
         seq.sort(key=lambda x: -x[1])
 


### PR DESCRIPTION
## Summary
- ensure rank_engine loops over positions in deterministic order

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v 'ranking/changelog.py')`

------
https://chatgpt.com/codex/tasks/task_e_687e95cfedfc83238e1edc173cf84e11