### PR TITLE
Integrate missing PR changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,7 @@ automatically runs the scrapers and ranking engine on a schedule. The
 generated `public/current_ros.json` file is then pushed to the
 `gh-pages` branch so it can be served as a publicly accessible JSON
 feed.
+
+The ranking engine consumes projections and usage metrics from the scrapers
+under `scrapers/`. Previous revisions referenced KeepTradeCut (KTC) values, but
+that data is no longer loaded or used in the scoring formula.

--- a/ranking/rank_engine.py
+++ b/ranking/rank_engine.py
@@ -6,11 +6,6 @@ def load_sleeper():
     path = Path("data/sleeper_players.json")
     return json.loads(path.read_text()) if path.exists() else {}
 
-def load_ktc():
-    path = Path("data/ktc_values.csv")
-    if not path.exists(): return {}
-    with path.open() as f:
-        return {row["player_name"]: float(row["value"]) for row in csv.DictReader(f)}
 
 def load_usage():
     path = Path("data/nflverse_usage.csv")
@@ -51,7 +46,6 @@ def load_prev():
 # ---------- core rank logic ----------
 def calc_rank():
     players = load_sleeper()
-    ktc = load_ktc()
     usage = load_usage()
     proj = load_ffa_proj()
     t_sched = load_team_sched()


### PR DESCRIPTION
## Summary
- pull in the "Remove unused KTC loader" change from PR #2
- note in README that KTC values are no longer used
- drop the unused `load_ktc` helper and reference

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e978e97c083238b8d41f90c917761