### PR TITLE
Set workflow to run every 6 hours

### DIFF
--- a/.github/workflows/ros.yml
+++ b/.github/workflows/ros.yml
@@ -2,7 +2,7 @@ name: ROS Pipeline
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '0 */6 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- adjust workflow schedule to every 6 hours

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: `SyntaxError` in `ranking/changelog.py`)*

------
https://chatgpt.com/codex/tasks/task_e_687e9b9a04c4832390989fca24c723a9