### PR TITLE
Add disclaimers documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,6 @@ feed.
 The ranking engine consumes projections and usage metrics from the scrapers
 under `scrapers/`. Previous revisions referenced KeepTradeCut (KTC) values, but
 that data is no longer loaded or used in the scoring formula.
+
+## Disclaimer
+See [docs/disclaimers.md](docs/disclaimers.md) for details on data permissions, predictive limitations and why these rankings are for informational purposes only.

--- a/docs/disclaimers.md
+++ b/docs/disclaimers.md
@@ -1,0 +1,10 @@
+# Disclaimers
+
+## Data Source Permissions
+This project pulls projection data from FantasyFootballAnalytics, usage metrics from NFLverse, and player metadata from Sleeper. All datasets are published publicly and allow non‑commercial reuse via their respective open licenses. No proprietary or paywalled information is collected.
+
+## Predictive Limitations
+The ranking engine is a basic points model driven by the public data above. It does not account for every factor that may influence real‑world performance. Unexpected injuries, coaching changes or other events can quickly render the projections inaccurate.
+
+## Informational Use Only
+The generated JSON files and any narrative summaries are provided for informational purposes. They should not be considered financial or gambling advice. Use the results at your own risk.


### PR DESCRIPTION
## Summary
- document data source permissions, predictive limitations and informational-only intent
- link to new disclaimers doc from README

## Testing
- `python -m py_compile export_json.py ranking/rank_engine.py scrapers/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687ea6f45a6483239650c51b06d0aed6