### PR TITLE
Improve scraper resilience

### DIFF
--- a/.github/workflows/ros.yml
+++ b/.github/workflows/ros.yml
@@ -18,8 +18,11 @@ jobs:
           python-version: '3.11'
       - run: pip install -r requirements.txt
       - run: python scrapers/ffa_projections.py
+        continue-on-error: true
       - run: python scrapers/schedule_weights.py
+        continue-on-error: true
       - run: python scrapers/usage_sync.py
+        continue-on-error: true
       - run: python export_json.py
       - name: Commit prev_ros.json
         run: |

--- a/scrapers/ffa_projections.py
+++ b/scrapers/ffa_projections.py
@@ -1,4 +1,5 @@
 import pandas as pd, requests, io
+from requests import RequestException
 from pathlib import Path
 
 URLS = [
@@ -15,7 +16,10 @@ HEADERS = ["player_name", "position", "team", "season_proj"]
 
 def fetch_first_available() -> pd.DataFrame | None:
     for url in URLS:
-        r = requests.get(url, timeout=30)
+        try:
+            r = requests.get(url, timeout=30)
+        except RequestException:
+            return None
         if r.status_code == 200:
             return pd.read_csv(io.StringIO(r.text))
     return None

--- a/scrapers/schedule_weights.py
+++ b/scrapers/schedule_weights.py
@@ -1,4 +1,5 @@
 import json, pandas as pd, requests, io
+from requests import RequestException
 from pathlib import Path
 
 TEAM_URL = ("https://raw.githubusercontent.com/nflverse/nflverse-data/master/"
@@ -7,7 +8,10 @@ POS_URL  = ("https://raw.githubusercontent.com/nflverse/nflverse-data/master/"
             "fantasy/sos/2025_player_sos.csv")
 
 def fetch_csv(url: str) -> pd.DataFrame | None:
-    r = requests.get(url, timeout=30)
+    try:
+        r = requests.get(url, timeout=30)
+    except RequestException:
+        return None
     return pd.read_csv(io.StringIO(r.text)) if r.status_code == 200 else None
 
 def main() -> None:

--- a/scrapers/usage_sync.py
+++ b/scrapers/usage_sync.py
@@ -1,4 +1,5 @@
 import pandas as pd, requests, io
+from requests import RequestException
 from pathlib import Path
 
 CSV_URL = (
@@ -7,7 +8,10 @@ CSV_URL = (
 )
 
 def fetch_usage() -> pd.DataFrame | None:
-    r = requests.get(CSV_URL, timeout=30)
+    try:
+        r = requests.get(CSV_URL, timeout=30)
+    except RequestException:
+        return None
     if r.status_code != 200:
         return None
     df = pd.read_csv(io.StringIO(r.text))


### PR DESCRIPTION
## Summary
- allow pipeline to continue when HTTP fetches fail
- ignore scraper step failures in CI

## Testing
- `pip install -r requirements.txt`
- `python scrapers/ffa_projections.py`
- `python scrapers/schedule_weights.py`
- `python scrapers/usage_sync.py`
- `python export_json.py`


------
https://chatgpt.com/codex/tasks/task_e_687eacd7e7d48323bf702c595206ef4d