### PR TITLE
Handle request failures gracefully

### DIFF
--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -11,5 +11,6 @@ Several public datasets feed into the rest-of-season rankings:
 - **Sleeper** – A JSON dump of player metadata (position, team, bye week and
   injury status) is expected at `data/sleeper_players.json`.
 
-Each scraper gracefully handles missing data by writing placeholder files so the
-ranking engine can still run even if a source is temporarily unavailable.
+Each scraper gracefully handles missing data. If a request fails and prior
+output exists, the scraper keeps the existing file. A placeholder is written
+only when no previous data is available so the ranking engine can continue.

--- a/scrapers/ffa_projections.py
+++ b/scrapers/ffa_projections.py
@@ -28,6 +28,11 @@ def main() -> None:
     Path("data").mkdir(exist_ok=True)
     df = fetch_first_available()
     if df is None:
+        if OUTFILE.exists():
+            print(
+                "⚠️  No FFA CSV available; kept existing ffa_proj.csv"
+            )
+            return
         # Write header-only placeholder so downstream code doesn’t crash
         pd.DataFrame(columns=HEADERS).to_csv(OUTFILE, index=False)
         print("⚠️  No FFA CSV available; wrote empty ffa_proj.csv")

--- a/scrapers/schedule_weights.py
+++ b/scrapers/schedule_weights.py
@@ -18,12 +18,18 @@ def main() -> None:
     team_df = fetch_csv(TEAM_URL)
     pos_df  = fetch_csv(POS_URL)
 
-    # if nflverse hasn’t published yet, write empty JSON so pipeline continues
+    Path("data").mkdir(exist_ok=True)
+    team_path = Path("data/team_sched.json")
+    pos_path = Path("data/pos_sched.json")
+
+    # if nflverse hasn’t published yet, keep existing JSON or write placeholders
     if team_df is None or pos_df is None:
-        Path("data").mkdir(exist_ok=True)
-        Path("data/team_sched.json").write_text("{}")
-        Path("data/pos_sched.json").write_text("{}")
-        print("⚠️  SOS CSVs unavailable; wrote empty JSON")
+        if team_path.exists() and pos_path.exists():
+            print("⚠️  SOS CSVs unavailable; kept existing JSON")
+        else:
+            team_path.write_text("{}")
+            pos_path.write_text("{}")
+            print("⚠️  SOS CSVs unavailable; wrote empty JSON")
         return
 
     team_adj = (team_df.set_index("team")["ros_fp_allowed"]

--- a/scrapers/usage_sync.py
+++ b/scrapers/usage_sync.py
@@ -24,13 +24,19 @@ def fetch_usage() -> pd.DataFrame | None:
 def main() -> None:
     usage = fetch_usage()
     Path("data").mkdir(exist_ok=True)
+    out_path = Path("data/nflverse_usage.csv")
     if usage is None:
+        if out_path.exists():
+            print(
+                "⚠️  usage CSV unavailable; kept existing nflverse_usage.csv"
+            )
+            return
         # write header-only CSV so ranking engine can still run
         pd.DataFrame(columns=["player_name", "route_run_share"]).to_csv(
-            "data/nflverse_usage.csv", index=False)
+            out_path, index=False)
         print("⚠️  usage CSV unavailable; wrote empty placeholder")
     else:
-        usage.to_csv("data/nflverse_usage.csv", index=False)
+        usage.to_csv(out_path, index=False)
         print("✅  updated data/nflverse_usage.csv")
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- preserve existing files in scrapers when network fetches fail
- write placeholder data only when no prior file exists
- document improved failure handling

## Testing
- `python -m py_compile scrapers/ffa_projections.py scrapers/schedule_weights.py scrapers/usage_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_687eaea54c54832388f231340b9dac79