### PR TITLE
Enable Sleeper player data and simplify ranking pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,15 @@ Each scraper pulls data from public sources and saves it under `data/`:
 python scrapers/ffa_projections.py   # projections from FFA
 python scrapers/schedule_weights.py  # strength of schedule
 python scrapers/usage_sync.py        # usage data from nflverse
+python scrapers/sleeper_players.py   # active player list from Sleeper
 ```
 
 ## How rankings are produced
 
 Run `python export_json.py` to execute `ranking/rank_engine.py`. The
 engine combines the downloaded datasets, computes the rest-of-season
-rankings and writes them to `public/current_ros.json`.
+rankings and writes them to `public/current_ros.json` and the simplified
+`public/ros_rankings.json`.
 
 ## Publishing the JSON
 

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -8,8 +8,8 @@ Several public datasets feed into the rest-of-season rankings:
 - **NFLverse** – Strength-of-schedule and usage metrics come from the NFLverse
   project. `schedule_weights.py` pulls positional and team adjustments while
   `usage_sync.py` downloads weekly usage statistics.
-- **Sleeper** – A JSON dump of player metadata (position, team, bye week and
-  injury status) is expected at `data/sleeper_players.json`.
+- **Sleeper** – Player metadata is pulled from the Sleeper API via
+   `scrapers/sleeper_players.py` and written to `data/sleeper_players.json`.
 
 Each scraper gracefully handles missing data. If a request fails and prior
 output exists, the scraper keeps the existing file. A placeholder is written

--- a/scrapers/sleeper_players.py
+++ b/scrapers/sleeper_players.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+import requests
+from requests import RequestException
+
+API_URL = "https://api.sleeper.app/v1/players/nfl"
+OUTFILE = Path("data/sleeper_players.json")
+
+KEEP_POS = {"QB", "RB", "WR", "TE", "DEF", "DST"}
+
+
+def main() -> None:
+    try:
+        r = requests.get(API_URL, timeout=30)
+    except RequestException:
+        r = None
+    if r is None or r.status_code != 200:
+        if OUTFILE.exists():
+            print("⚠️  Sleeper API unavailable; kept existing JSON")
+            return
+        OUTFILE.write_text("{}")
+        print("⚠️  Sleeper API unavailable; wrote empty JSON")
+        return
+
+    all_players = r.json()
+    players = {}
+    for pid, info in all_players.items():
+        if not info.get("active"):
+            continue
+        pos = info.get("position")
+        if pos == "DEF":
+            pos = "DST"
+        if pos not in KEEP_POS:
+            continue
+        players[pid] = {
+            "full_name": info.get("full_name"),
+            "position": pos,
+            "team": info.get("team"),
+            "injury_status": info.get("injury_status"),
+            "age": info.get("age"),
+        }
+
+    Path("data").mkdir(exist_ok=True)
+    OUTFILE.write_text(json.dumps(players, indent=2))
+    print(f"✅  wrote {OUTFILE}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- pull active player data from Sleeper
- simplify ranking engine to rank all active players by age
- document the new scraper and output files

## Testing
- `python -m py_compile export_json.py scrapers/*.py ranking/freshness.py ranking/rank_engine.py gpt_summary.py`
- `python export_json.py`

------
https://chatgpt.com/codex/tasks/task_e_687eb4bc30d08323a13cba93647f2613