### PR TITLE
Add simple ROS points tests and CI workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install pytest
+    - name: Run tests
+      run: pytest

--- a/ranking/__init__.py
+++ b/ranking/__init__.py
@@ -1,0 +1,1 @@
+# Package for ranking modules

--- a/tests/test_rank_engine.py
+++ b/tests/test_rank_engine.py
@@ -1,0 +1,15 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pytest
+from ranking.rank_engine import compute_ros_points
+
+@pytest.mark.parametrize("age,expected", [
+    (25, 75.0),
+    (30, 70.0),
+    (0, 100.0),
+    (None, 0.0),
+    (120, 0.0),
+])
+def test_compute_ros_points(age, expected):
+    player = {"age": age}
+    assert compute_ros_points(player) == expected


### PR DESCRIPTION
## Summary
- add `ranking/__init__.py` so tests can import project modules
- create a basic test for `compute_ros_points`
- configure GitHub Actions to install dependencies and run `pytest`

## Testing
- `pip install -r requirements.txt`
- `pip install pytest`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687eb9a3a6608323a2ed594a629d144a