### PR TITLE
Fix detached HEAD push issue

### DIFF
--- a/.github/workflows/ros.yml
+++ b/.github/workflows/ros.yml
@@ -32,7 +32,8 @@ jobs:
           git config user.email github-actions@github.com
           git add public/prev_ros.json
           git commit -m "Update prev_ros.json" || echo "No changes"
-          git push
+          # explicit ref to handle detached HEAD on schedule runs
+          git push origin HEAD:main
       - name: Publish JSON to gh-pages
         uses: peaceiris/actions-gh-pages@v4
         with:


### PR DESCRIPTION
## Summary
- fix gh-pages push when workflow runs on a schedule

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ebb2dc4848323b10d3ccfa576b586