### PR TITLE
Fix commit step for JSON files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,8 @@ __pycache__/
 
 # Generated folders
 /data/
-/public/
+/public/*
+!/public/
+!/public/prev_ros.json
+!/public/current_ros.json
+!/public/ros_rankings.json


### PR DESCRIPTION
## Summary
- allow tracked JSON files under `public/` so GitHub Actions can commit updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ebd21eeb483238dcb791985782ba8